### PR TITLE
Minor cleanups for the Flink implementation

### DIFF
--- a/flink-benchmarks/src/main/resources/log4j.properties
+++ b/flink-benchmarks/src/main/resources/log4j.properties
@@ -1,0 +1,29 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, testlogger
+
+log4j.appender.testlogger=org.apache.log4j.ConsoleAppender
+log4j.appender.testlogger.target = System.err
+log4j.appender.testlogger.layout=org.apache.log4j.PatternLayout
+log4j.appender.testlogger.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+
+# suppress the irrelevant (wrong) warnings from the netty channel handler
+log4j.logger.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, testlogger
+
+


### PR DESCRIPTION
I've cleaned up the Flink implementation a bit:
- I removed the `print()` statements of the intermediate streams. `print()` will print the stream to the worker's stdout. In thise case, there were 5 print statements, for each intermediate stream.
- I added new configuration parameters for setting the buffer timeout (affects latency / throughput)
- I added a config param for enabling fault tolerance (disabled by default)
- The parallelism is now set to use all cluster resources. Ideally, the parallelism is set to the total number of slots available in the overall cluster. So if there are 10 Taskmanagers with 16 slots, Flink can run with a parallelism of 160. Also note that you can set a default parallelism on the ExecutionEnvironment for all operators.

Thanks a lot for the great work with the benchmarks!