### PR TITLE
Fix build error when mvn uses JDK 1.3 by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,4 +129,17 @@ Licensed under the terms of the Apache License 2.0. Please see LICENSE file in t
         <module>flink-benchmarks</module>
         <module>spark-benchmarks</module>
     </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
This is a common error when not specifying the version of JDK that maven uses. It will lead to an error
`error: generics are not supported in -source 1.3` that stops the setup of the `streaming-benchmark-common`.