### PR TITLE
add Kafka Streams benchmarks, updated frameworks versions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,6 +18,7 @@ It takes a list of operations to perform, and options are passed into the script
    * SETUP - download dependencies (Storm, Spark, Flink, Redis, and Kafka) cleans out any temp files and compiles everything
    * STORM_TEST - Run the test using Storm on a single node
    * SPARK_TEST - Run the test using Spark on a single node
+   * KAFKA_STREAMS_TEST - Run the test using Kafka Streams on a single node
    * FLINK_TEST - Run the test using Flink on a single node
    * APEX_TEST  - Run the test using Apex on a single node
    * STOP_ALL - If something goes wrong stop all processes that were launched for the test.

--- a/apex-benchmarks/pom.xml
+++ b/apex-benchmarks/pom.xml
@@ -4,19 +4,19 @@
 
   <groupId>com.example</groupId>
   <version>1.0-SNAPSHOT</version>
-  <artifactId>apex_benchmark</artifactId>
+  <artifactId>apex-benchmark</artifactId>
   <packaging>jar</packaging>
 
   <!-- change these to the appropriate values -->
-  <name>Apex_Benchmark</name>
+  <name>apex-benchmarks</name>
   <description>My Apex Application Description</description>
 
   <properties>
     <!-- change this if you desire to use a different version of Apex -->
-    <apex.version>3.4.0</apex.version>
+    <apex.version>3.6.0</apex.version>
     <apex.apppackage.classpath>lib/*.jar</apex.apppackage.classpath>
-    <malhar.version>3.4.0</malhar.version>
-    <megh.version>3.4.0</megh.version>
+    <malhar.version>3.6.0</malhar.version>
+    <megh.version>3.5.0</megh.version>
   </properties>
 
   <build>
@@ -298,12 +298,6 @@
       <artifactId>apex-common</artifactId>
       <version>${apex.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.10</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/apex-benchmarks/src/main/java/apex/benchmark/Application.java
+++ b/apex-benchmarks/src/main/java/apex/benchmark/Application.java
@@ -14,7 +14,7 @@ import com.datatorrent.api.StreamingApplication;
 import com.datatorrent.api.annotation.ApplicationAnnotation;
 import com.datatorrent.contrib.kafka.KafkaSinglePortStringInputOperator;
 
-@ApplicationAnnotation(name = "Apex_Benchmark")
+@ApplicationAnnotation(name = "apex-benchmark")
 public class Application implements StreamingApplication
 {
   @Override

--- a/conf/apex.xml
+++ b/conf/apex.xml
@@ -23,7 +23,7 @@
 
       <property>
         <name>dt.operator.kafkaInput.prop.consumer.zookeeper</name>
-        <value>node21.morado.com:2181</value>
+        <value>localhost:2181</value>
       </property>
 
       <property>
@@ -43,12 +43,12 @@
 
       <property>
         <name>dt.operator.redisJoin.redisServerHost</name>
-        <value>node35.morado.com</value>
+        <value>localhost</value>
       </property>
 
       <property>
         <name>dt.operator.campaignProcessor.redisServerHost</name>
-        <value>node35.morado.com</value>
+        <value>localhost</value>
      </property>
 
 </configuration>

--- a/data/project.clj
+++ b/data/project.clj
@@ -5,7 +5,8 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/tools.cli "0.3.3"]
                  [org.clojars.tavisrudd/redis-clojure "1.3.1"]
-                 [clj-kafka "0.3.2"]
+                 [io.weft/gregor "0.5.0"]
+                 [mount "0.1.11"]
                  [clj-json "0.5.3"]
                  [clj-yaml "0.4.0"]]
   :main setup.core

--- a/flink-benchmarks/pom.xml
+++ b/flink-benchmarks/pom.xml
@@ -27,14 +27,14 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java_2.10</artifactId>
-	    <version>1.1.3</version>
+            <artifactId>flink-streaming-java_2.11</artifactId>
+	    <version>1.3.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-kafka-0.8_2.10</artifactId>
-	    <version>1.1.3</version>
+            <artifactId>flink-connector-kafka-0.10_2.11</artifactId>
+	    <version>1.3.1</version>
         </dependency>
         <dependency>
             <groupId>com.yahoo.stream</groupId>

--- a/kafka-streams-benchmarks/pom.xml
+++ b/kafka-streams-benchmarks/pom.xml
@@ -1,8 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- Copyright 2015, Yahoo Inc.
- Licensed under the terms of the Apache License 2.0. Please see LICENSE file in the project root for terms.
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -13,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>spark-benchmarks</artifactId>
+    <artifactId>kafka-streams-benchmarks</artifactId>
     <packaging>jar</packaging>
 
     <repositories>
@@ -37,18 +33,17 @@
             <artifactId>jedis</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <scope>provided</scope>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-streaming_${scala.binary.version}</artifactId>
-            <scope>provided</scope>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-streaming-kafka-0-10_${scala.binary.version}</artifactId>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_${scala.binary.version}</artifactId>
+            <version>0.10.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.sedis</groupId>
@@ -61,6 +56,18 @@
         <dependency>
             <groupId>com.yahoo.stream</groupId>
             <artifactId>streaming-benchmark-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.twitter</groupId>
+            <artifactId>chill_${scala.binary.version}</artifactId>
         </dependency>
     </dependencies>
 
@@ -100,6 +107,7 @@
                         <arg>-unchecked</arg>
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
+                        <arg>-Xexperimental</arg>
                     </args>
                     <jvmArgs>
                         <jvmArg>-Xms1024m</jvmArg>
@@ -122,9 +130,9 @@
                     <minimizeJar>false</minimizeJar>
                     <transformers>
                         <transformer
-                          implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                         <transformer
-                          implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                                implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
                     </transformers>
                 </configuration>
                 <executions>
@@ -135,6 +143,18 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.3.1</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>streams.benchmarks.AdvertisingKafkaStreams</mainClass>
+                            <addClasspath>true</addClasspath>
+                        </manifest>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/kafka-streams-benchmarks/src/main/resources/log4j.properties
+++ b/kafka-streams-benchmarks/src/main/resources/log4j.properties
@@ -1,0 +1,8 @@
+# Root logger option
+log4j.rootLogger=INFO, stdout
+
+# Direct log messages to stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/kafka-streams-benchmarks/src/main/scala/streams/benchmarks/AdvertisingKafkaStreams.scala
+++ b/kafka-streams-benchmarks/src/main/scala/streams/benchmarks/AdvertisingKafkaStreams.scala
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2015, Yahoo Inc.
+ * Licensed under the terms of the Apache License 2.0. Please see LICENSE file in the project root for terms.
+ */
+
+// scalastyle:off println
+
+package streams.benchmarks
+
+import java.util
+import java.util.{Properties, UUID}
+
+import benchmark.common.Utils
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization.Serdes
+import org.apache.kafka.streams.kstream.{KStream, KStreamBuilder, Reducer}
+import org.apache.kafka.streams.processor.TopologyBuilder
+import org.apache.kafka.streams.{KafkaStreams, StreamsConfig}
+import org.json.JSONObject
+import org.sedis._
+import redis.clients.jedis._
+import streams.benchmarks.KeyValueImplicits._
+import streams.benchmarks.StringLongSerde._
+
+import scala.collection.JavaConverters._
+import scala.compat.Platform.currentTime
+
+
+object AdvertisingKafkaStreams {
+  type Int = java.lang.Integer
+
+  def main(args: Array[String]) {
+    val appId = "AdvertisingKafkaStreams"
+    val commonConfig = Utils.findAndReadConfigFile(args(0), true).asInstanceOf[java.util.Map[String, Any]]
+    val batchSize = commonConfig.get("kafka.committime") match {
+      case n: Number => n.longValue()
+      case other => throw new ClassCastException(other + " not a Number")
+    }
+    val topic = commonConfig.get("kafka.topic") match {
+      case s: String => s
+      case other => throw new ClassCastException(other + " not a String")
+    }
+
+    val redisHost = commonConfig.get("redis.host") match {
+      case s: String => s
+      case other => throw new ClassCastException(other + " not a String")
+    }
+
+    val kafkaHosts = commonConfig.get("kafka.brokers").asInstanceOf[java.util.List[String]] match {
+      case l: java.util.List[String] => l.asScala
+      case other => throw new ClassCastException(other + " not a List[String]")
+    }
+    val kafkaPort = commonConfig.get("kafka.port") match {
+      case n: Number => n.toString
+      case other => throw new ClassCastException(other + " not a Number")
+    }
+    val brokers = joinHosts(kafkaHosts, kafkaPort)
+
+    val props = new Properties()
+    props.put(StreamsConfig.APPLICATION_ID_CONFIG, appId)
+    props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, batchSize.toString)
+    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, brokers)
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+    props.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass.getName)
+    props.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass.getName)
+
+    implicit val stringSerde = Serdes.String
+
+    val pool = new Pool(new JedisPool(new JedisPoolConfig(), redisHost, 6379, 2000))
+    val streamBuilder = new KStreamBuilder
+    val messages = streamBuilder.stream[String, String](TopologyBuilder.AutoOffsetReset.EARLIEST, topic)
+
+    //We can repartition to use more executors if desired
+    //    val messages_repartitioned = messages.repartition(10)
+
+    //Parse the String as JSON
+    val kafkaData: KStream[String, Array[String]] = messages.mapValues[Array[String]]((v: String) => parseJson(v))
+
+    //Filter the records if event type is "view"
+    val filteredOnView: KStream[String, Array[String]] = kafkaData.filter((_, arr) => arr(4).equals("view"))
+
+    //project the event, basically filter the fields.
+    val projected: KStream[String, Array[String]] = filteredOnView.mapValues[Array[String]](eventProjection)
+
+    //Note that the Storm benchmark caches the results from Redis, we don't do that here yet
+    val redisJoined: KStream[String, Array[String]] = projected.mapValues(queryRedisTopLevel(_, redisHost, pool))
+
+    //each record in the RDD: key:(campaign_id : String, window_time: Long),  Value: (ad_id : String)
+    //DStream[((String,Long),String)]
+    val campaign_timeStamp: KStream[StringLongTuple, String] = redisJoined.map[StringLongTuple, String]((_, v) => {
+      val t = campaignTime(v)
+      (t._1, t._2)
+    })
+
+    // since we're just counting use reduceByKey
+    val totalEventsPerCampaignTime = campaign_timeStamp
+      .mapValues[Int](_ => 1)
+      .groupByKey(StringLongSerde.serde, Serdes.Integer())
+      .reduce(
+      new Reducer[Int] {
+        override def apply(v: Int, v1: Int): Int = v + v1
+      }, appId + "Reduce")
+
+    totalEventsPerCampaignTime.foreach((k, v) => writeWindow(pool, (k, v)))
+
+    // Start the computation
+    val kafkaStreams = new KafkaStreams(streamBuilder, props)
+    sys.addShutdownHook({
+      kafkaStreams.close()
+      pool.underlying.getResource.close()
+    })
+    kafkaStreams.start()
+  }
+
+  def joinHosts(hosts: Seq[String], port: String): String = {
+    val joined = new StringBuilder()
+    hosts.foreach({
+      if (joined.nonEmpty) {
+        joined.append(",")
+      }
+
+      joined.append(_).append(":").append(port)
+    })
+    joined.toString()
+  }
+
+  def parseJson(jsonString: String): Array[String] = {
+    val parser = new JSONObject(jsonString)
+    Array(
+      parser.getString("user_id"),
+      parser.getString("page_id"),
+      parser.getString("ad_id"),
+      parser.getString("ad_type"),
+      parser.getString("event_type"),
+      parser.getString("event_time"),
+      parser.getString("ip_address"))
+  }
+
+  def eventProjection(event: Array[String]): Array[String] = {
+    Array(
+      event(2), //ad_id
+      event(5)) //event_time
+  }
+
+  def queryRedisTopLevel(event: Array[String], redisHost: String, pool: Pool): Array[String] = {
+    val ad_to_campaign = new util.HashMap[String, String]()
+    queryRedis(pool, ad_to_campaign, event)
+  }
+
+  def queryRedis(pool: Pool, ad_to_campaign: util.HashMap[String, String], event: Array[String]): Array[String] = {
+    val ad_id = event(0)
+    val campaign_id_cache = ad_to_campaign.get(ad_id)
+    if (campaign_id_cache == null) {
+      pool.withJedisClient { client =>
+        val campaign_id_temp = Dress.up(client).get(ad_id)
+        if (campaign_id_temp.isDefined) {
+          val campaign_id = campaign_id_temp.get
+          ad_to_campaign.put(ad_id, campaign_id)
+          Array(campaign_id, event(0), event(1))
+          //campaign_id, ad_id, event_time
+        } else {
+          Array("Campaign_ID not found in either cache nore Redis for the given ad_id!", event(0), event(1))
+        }
+      }
+    } else {
+      Array(campaign_id_cache, event(0), event(1))
+    }
+  }
+
+  def campaignTime(event: Array[String]): (StringLongTuple, String) = {
+    val time_divisor: Long = 10000L
+    ((event(0), time_divisor * (event(2).toLong / time_divisor)), event(1))
+    //Key: (campaign_id, window_time),  Value: ad_id
+  }
+
+  private def writeWindow(pool: Pool, campaign_window_counts: ((String, Long), Int)): String = {
+    val campaign_window_pair = campaign_window_counts._1
+    val campaign = campaign_window_pair._1
+    val window_timestamp = campaign_window_pair._2.toString
+    val window_seenCount = campaign_window_counts._2.toLong
+    pool.withJedisClient { client =>
+
+      val dressUp = Dress.up(client)
+      var windowUUID = dressUp.hmget(campaign, window_timestamp).head
+      if (windowUUID == null) {
+        windowUUID = UUID.randomUUID().toString
+        dressUp.hset(campaign, window_timestamp, windowUUID)
+        var windowListUUID: String = dressUp.hmget(campaign, "windows").head
+        if (windowListUUID == null) {
+          windowListUUID = UUID.randomUUID.toString
+          dressUp.hset(campaign, "windows", windowListUUID)
+        }
+        dressUp.lpush(windowListUUID, window_timestamp)
+      }
+      dressUp.hincrBy(windowUUID, "seen_count", window_seenCount)
+      dressUp.hset(windowUUID, "time_updated", currentTime.toString)
+      return window_seenCount.toString
+    }
+
+  }
+}

--- a/kafka-streams-benchmarks/src/main/scala/streams/benchmarks/KeyValueImplicits.scala
+++ b/kafka-streams-benchmarks/src/main/scala/streams/benchmarks/KeyValueImplicits.scala
@@ -1,0 +1,14 @@
+package streams.benchmarks
+
+import org.apache.kafka.streams.KeyValue
+
+import scala.language.implicitConversions
+
+/**
+  * Implicit conversions that provide us with some syntactic sugar when writing stream transformations.
+  */
+object KeyValueImplicits {
+
+  implicit def Tuple2ToKeyValue[K, V](tuple: (K, V)): KeyValue[K, V] = new KeyValue(tuple._1, tuple._2)
+
+}

--- a/kafka-streams-benchmarks/src/main/scala/streams/benchmarks/StringLongTuple.scala
+++ b/kafka-streams-benchmarks/src/main/scala/streams/benchmarks/StringLongTuple.scala
@@ -1,0 +1,41 @@
+package streams.benchmarks
+
+import java.util
+
+import org.apache.kafka.common.serialization.{Deserializer, Serde, Serdes, Serializer}
+import com.twitter.chill.ScalaKryoInstantiator
+import org.apache.kafka.common.errors.SerializationException
+
+import scala.language.implicitConversions
+
+case class StringLongTuple(str: String, l: Long)
+
+class StringLongSerializer extends Serializer[StringLongTuple] {
+  override def configure(map: util.Map[String, _], b: Boolean): Unit = {}
+
+  override def serialize(s: String, t: StringLongTuple): Array[Byte] = {
+    if (t == null) null
+    else ScalaKryoInstantiator.defaultPool.toBytesWithClass(t)
+  }
+
+  override def close(): Unit = {}
+}
+
+
+class StringLongDeserializer extends Deserializer[StringLongTuple] {
+  override def configure(map: util.Map[String, _], b: Boolean): Unit = {}
+
+  override def deserialize(s: String, bytes: Array[Byte]): StringLongTuple = {
+    if (bytes == null) null
+    else if (bytes.isEmpty) throw new SerializationException("byte array must not be empty")
+    else ScalaKryoInstantiator.defaultPool.fromBytes(bytes).asInstanceOf[StringLongTuple]
+  }
+
+  override def close(): Unit = {}
+}
+
+object StringLongSerde {
+  val serde: Serde[StringLongTuple] = Serdes.serdeFrom(new StringLongSerializer, new StringLongDeserializer)
+  implicit def tuple2stringLong(t: (String, Long)): StringLongTuple = StringLongTuple(t._1, t._2)
+  implicit def stringLong2tuple(t: StringLongTuple): (String, Long) = (t.str, t.l)
+}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
 Copyright 2015, Yahoo Inc.
 Licensed under the terms of the Apache License 2.0. Please see LICENSE file in the project root for terms.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.yahoo.stream</groupId>
     <artifactId>yahoo-low-latency-bechmarks</artifactId>
@@ -15,19 +16,21 @@ Licensed under the terms of the Apache License 2.0. Please see LICENSE file in t
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <spark.version>1.6.2</spark.version>
-        <kafka.version>0.8.2.1</kafka.version>
-        <flink.version>1.1.3</flink.version>
+        <spark.version>2.1.1</spark.version>
+        <kafka.version>0.10.2.1</kafka.version>
+        <flink.version>1.3.1</flink.version>
         <storm.version>0.9.7</storm.version>
-        <scala.binary.version>2.10</scala.binary.version>
-        <scala.version>2.10.4</scala.version>
+        <scala.binary.version>2.11</scala.binary.version>
+        <scala.version>2.11.11</scala.version>
         <json.version>20140107</json.version>
-        <jedis.version>2.4.2</jedis.version>
+        <jedis.version>2.9.0</jedis.version>
         <sedis.version>1.2.2</sedis.version>
-        <slf4j.version>1.7.7</slf4j.version>
+        <slf4j.version>1.7.25</slf4j.version>
+        <log4j.version>1.2.17</log4j.version>
+        <chill.version>0.9.2</chill.version>
         <commons-cli.version>1.3.1</commons-cli.version>
         <snakeyaml.version>1.11</snakeyaml.version>
-        <apex.version>3.4.0</apex.version>
+        <apex.version>3.6.0</apex.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -55,6 +58,11 @@ Licensed under the terms of the Apache License 2.0. Please see LICENSE file in t
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+                <version>${log4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.flink</groupId>
@@ -108,8 +116,18 @@ Licensed under the terms of the Apache License 2.0. Please see LICENSE file in t
             </dependency>
             <dependency>
                 <groupId>org.apache.spark</groupId>
-                <artifactId>spark-streaming-kafka_${scala.binary.version}</artifactId>
+                <artifactId>spark-streaming-kafka-0-10_${scala.binary.version}</artifactId>
                 <version>${spark.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-streams</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.sedis</groupId>
@@ -121,6 +139,11 @@ Licensed under the terms of the Apache License 2.0. Please see LICENSE file in t
                 <artifactId>scala-library</artifactId>
                 <version>${scala.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.twitter</groupId>
+                <artifactId>chill_${scala.binary.version}</artifactId>
+                <version>${chill.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -129,6 +152,7 @@ Licensed under the terms of the Apache License 2.0. Please see LICENSE file in t
         <module>storm-benchmarks</module>
         <module>flink-benchmarks</module>
         <module>spark-benchmarks</module>
+        <module>kafka-streams-benchmarks</module>
         <module>apex-benchmarks</module>
     </modules>
 
@@ -138,8 +162,8 @@ Licensed under the terms of the Apache License 2.0. Please see LICENSE file in t
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/spark-benchmarks/src/main/scala/spark/benchmarks/AdvertisingSpark.scala
+++ b/spark-benchmarks/src/main/scala/spark/benchmarks/AdvertisingSpark.scala
@@ -1,3 +1,5 @@
+package spark.benchmarks
+
 /*
  * Copyright 2015, Yahoo Inc.
  * Licensed under the terms of the Apache License 2.0. Please see LICENSE file in the project root for terms.
@@ -5,29 +7,25 @@
 
 // scalastyle:off println
 
-package spark.benchmark
-
 import java.util
+import java.util.UUID
 
-import kafka.serializer.StringDecoder
-import org.apache.spark.streaming
-import org.apache.spark.streaming.{Milliseconds, StreamingContext}
-
-import org.apache.spark.streaming.kafka.KafkaUtils
-import org.apache.spark.streaming.dstream
+import benchmark.common.Utils
+import org.apache.kafka.common.serialization.StringDeserializer
 import org.apache.spark.SparkConf
+import org.apache.spark.streaming.kafka010.ConsumerStrategies.Subscribe
+import org.apache.spark.streaming.kafka010.KafkaUtils
+import org.apache.spark.streaming.kafka010.LocationStrategies.PreferConsistent
+import org.apache.spark.streaming.{Milliseconds, StreamingContext}
 import org.json.JSONObject
 import org.sedis._
 import redis.clients.jedis._
-import scala.collection.Iterator
-import org.apache.spark.rdd.RDD
-import java.util.{UUID, LinkedHashMap}
-import compat.Platform.currentTime
-import benchmark.common.Utils
-import scala.collection.JavaConverters._
-import scala.collection.mutable.Buffer
 
-object KafkaRedisAdvertisingStream {
+import scala.collection.Iterator
+import scala.collection.JavaConverters._
+import scala.compat.Platform.currentTime
+
+object AdvertisingSpark {
   def main(args: Array[String]) {
 
     val commonConfig = Utils.findAndReadConfigFile(args(0), true).asInstanceOf[java.util.Map[String, Any]];
@@ -44,28 +42,37 @@ object KafkaRedisAdvertisingStream {
       case s: String => s
       case other => throw new ClassCastException(other + " not a String")
     }
-    
+
     // Create context with 2 second batch interval
     val sparkConf = new SparkConf().setAppName("KafkaRedisAdvertisingStream")
     val ssc = new StreamingContext(sparkConf, Milliseconds(batchSize))
 
     val kafkaHosts = commonConfig.get("kafka.brokers").asInstanceOf[java.util.List[String]] match {
-      case l: java.util.List[String] => l.asScala.toSeq
+      case l: java.util.List[String] => l.asScala
       case other => throw new ClassCastException(other + " not a List[String]")
     }
     val kafkaPort = commonConfig.get("kafka.port") match {
-      case n: Number => n.toString()
+      case n: Number => n.toString
       case other => throw new ClassCastException(other + " not a Number")
     }
 
     // Create direct kafka stream with brokers and topics
     val topicsSet = Set(topic)
     val brokers = joinHosts(kafkaHosts, kafkaPort)
-    val kafkaParams = Map[String, String]("metadata.broker.list" -> brokers, "auto.offset.reset" -> "smallest")
+    val kafkaParams = Map[String, Object](
+      "group.id" -> "AdvertisingSpark",
+      "bootstrap.servers" -> brokers,
+      "auto.offset.reset" -> "earliest",
+      "key.deserializer" -> classOf[StringDeserializer],
+      "value.deserializer" -> classOf[StringDeserializer]
+    )
     System.err.println(
       "Trying to connect to Kafka at " + brokers)
-    val messages = KafkaUtils.createDirectStream[String, String, StringDecoder, StringDecoder](
-      ssc, kafkaParams, topicsSet)
+    val messages = KafkaUtils.createDirectStream[String, String](
+      ssc,
+      PreferConsistent,
+      Subscribe[String, String](topicsSet, kafkaParams)
+    )
 
     //We can repartition to use more executors if desired
     //    val messages_repartitioned = messages.repartition(10)
@@ -73,21 +80,21 @@ object KafkaRedisAdvertisingStream {
 
     //take the second tuple of the implicit Tuple2 argument _, by calling the Tuple2 method ._2
     //The first tuple is the key, which we don't use in this benchmark
-    val kafkaRawData = messages.map(_._2)
+    val kafkaRawData = messages.map(_.value())
 
     //Parse the String as JSON
-    val kafkaData = kafkaRawData.map(parseJson(_))
+    val kafkaData = kafkaRawData.map(parseJson)
 
     //Filter the records if event type is "view"
-    val filteredOnView = kafkaData.filter(_(4).equals("view"))
+    val filteredOnView = kafkaData.filter(arr => arr(4).equals("view"))
 
     //project the event, basically filter the fileds.
-    val projected = filteredOnView.map(eventProjection(_))
+    val projected = filteredOnView.map(eventProjection)
 
     //Note that the Storm benchmark caches the results from Redis, we don't do that here yet
-    val redisJoined = projected.mapPartitions(queryRedisTopLevel(_, redisHost), false)
+    val redisJoined = projected.mapPartitions(queryRedisTopLevel(_, redisHost), preservePartitioning = false)
 
-    val campaign_timeStamp = redisJoined.map(campaignTime(_))
+    val campaign_timeStamp = redisJoined.map(campaignTime)
     //each record in the RDD: key:(campaign_id : String, window_time: Long),  Value: (ad_id : String)
     //DStream[((String,Long),String)]
 
@@ -110,15 +117,15 @@ object KafkaRedisAdvertisingStream {
   }
 
   def joinHosts(hosts: Seq[String], port: String): String = {
-    val joined = new StringBuilder();
+    val joined = new StringBuilder()
     hosts.foreach({
-      if (!joined.isEmpty) {
-        joined.append(",");
+      if (joined.nonEmpty) {
+        joined.append(",")
       }
 
-      joined.append(_).append(":").append(port);
+      joined.append(_).append(":").append(port)
     })
-    return joined.toString();
+    joined.toString()
   }
 
   def parseJson(jsonString: String): Array[String] = {
@@ -141,10 +148,10 @@ object KafkaRedisAdvertisingStream {
 
   def queryRedisTopLevel(eventsIterator: Iterator[Array[String]], redisHost: String): Iterator[Array[String]] = {
     val pool = new Pool(new JedisPool(new JedisPoolConfig(), redisHost, 6379, 2000))
-    var ad_to_campaign = new util.HashMap[String, String]();
+    var ad_to_campaign = new util.HashMap[String, String]()
     val eventsIteratorMap = eventsIterator.map(event => queryRedis(pool, ad_to_campaign, event))
-    pool.underlying.getResource.close
-    return eventsIteratorMap
+    pool.underlying.getResource.close()
+    eventsIteratorMap
   }
 
   def queryRedis(pool: Pool, ad_to_campaign: util.HashMap[String, String], event: Array[String]): Array[String] = {
@@ -153,7 +160,7 @@ object KafkaRedisAdvertisingStream {
     if (campaign_id_cache==null) {
       pool.withJedisClient { client =>
         val campaign_id_temp = Dress.up(client).get(ad_id)
-        if (campaign_id_temp != None) {
+        if (campaign_id_temp.isDefined) {
           val campaign_id = campaign_id_temp.get
           ad_to_campaign.put(ad_id, campaign_id)
           Array(campaign_id, event(0), event(1))
@@ -178,7 +185,7 @@ object KafkaRedisAdvertisingStream {
 
     campaign_window_counts_Iterator.foreach(campaign_window_counts => writeWindow(pool, campaign_window_counts))
 
-    pool.underlying.getResource.close
+    pool.underlying.getResource.close()
   }
 
   private def writeWindow(pool: Pool, campaign_window_counts: ((String, Long), Int)) : String = {
@@ -189,11 +196,11 @@ object KafkaRedisAdvertisingStream {
     pool.withJedisClient { client =>
 
       val dressUp = Dress.up(client)
-      var windowUUID = dressUp.hmget(campaign, window_timestamp)(0)
+      var windowUUID = dressUp.hmget(campaign, window_timestamp).head
       if (windowUUID == null) {
         windowUUID = UUID.randomUUID().toString
         dressUp.hset(campaign, window_timestamp, windowUUID)
-        var windowListUUID: String = dressUp.hmget(campaign, "windows")(0)
+        var windowListUUID: String = dressUp.hmget(campaign, "windows").head
         if (windowListUUID == null) {
           windowListUUID = UUID.randomUUID.toString
           dressUp.hset(campaign, "windows", windowListUUID)

--- a/storm-benchmarks/pom.xml
+++ b/storm-benchmarks/pom.xml
@@ -28,6 +28,16 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${scala.binary.version}</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
- add Kafka Streams (0.10.2.1) benchmark corresponding to Spark's benchmark
- add options KAFKA_STREAMS_TEST, KAFKA_STREAMS_START and KAFKA_STREAMS_STOP to start one Kafka Streams instance with stream-bench.sh
- add Kafka Streams info to README and stream-bench.sh
- update Kafka to 0.10.2.1
- update Scala version to match Kafka needs to 2.11.11
- update Clojure producer to use a 0.10 Kafka producer (needed for Kafka Streams)
- update Spark to 2.1.1
- update Flink to 1.3.1
- update Apex to 3.6.0
- edit Apex source repository to current one
- cleanup some code in Spark benchmark
- update Kafka Consumer to 0.10 on Spark and Flink
- fixme Apex benchmark is not working, but it wasn't either in the previous version
- fix some variables to have a better default value in Flink
- edit ZK variables to match benchmark's defaults in Apex config
- fix some typos in various files